### PR TITLE
Version and wrapper-options are not working with grunt

### DIFF
--- a/tasks/cancompile.js
+++ b/tasks/cancompile.js
@@ -9,7 +9,10 @@ module.exports = function (grunt) {
 		var files = grunt.file.expand(this.data.src);
 
 		options.out = options.out || 'views.production.js';
-
+		if (options.options) {
+			options.wrapper = options.options.wrapper;
+			options.version = options.options.version;
+		}
 		compiler(files, options, function(err, output, outfile) {
 			if(err) {
 				return done(err);


### PR DESCRIPTION
...as those options are supposed to be in options.options

options is:

```
{
    src: '*.mustache',
    out: 'filename.js',
    options: {
        version: '2.0.0-pre'
    }
}
```
