### PR TITLE
Implement can.Component/tag-support

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -41,6 +41,13 @@ module.exports = function (options, callback) {
 		}
 
 		var can = win.can;
+
+		if (options.tags && options.tags.length) {
+                        for (var i = 0; i < options.tags.length; i++) {
+                                can.view.Scanner.tags[options.tags[i]] = function () {};
+                        }
+                }
+
 		var type = filename.substring(filename.lastIndexOf('.') + 1, filename.length);
 		var text = fs.readFileSync(filename).toString();
 		// Create an id from the normalized filename

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,6 +18,7 @@ module.exports = function (files, configuration, callback, log) {
         filename: file,
         normalizer: normalizer,
         log: log,
+	tags: configuration.tags,
         version: configuration.version
       }, function (error, compiled, id) {
 				if (error) {


### PR DESCRIPTION
Added support for can.Component-tags when configured in Gruntfile. This is a very simple approach, but I needed a solution asap.

```
dist: {
    tags: ['componentTag1', 'componentTag2']
}
```
