### PR TITLE
Requirejs Grunt example mustache and stache

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -173,6 +173,7 @@ To use your pre-compile views with [RequireJS](http://requirejs.org/) just add a
 that uses the AMD definition to load `can/view/mustache` and/or `can/view/ejs` (depending on what you are using).
 In a Grunt task:
 
+Mustache:
 ```js
 module.exports = function (grunt) {
   // Project configuration.
@@ -182,7 +183,25 @@ module.exports = function (grunt) {
     },
     cancompile: {
       dist: {
-        src: ['**/*.mustache'],
+        src: ['**/*.mustache', '!node_modules/**/*.mustache'],
+        dest: 'production/views.production.js',
+      }
+    }
+  });
+}
+```
+
+Stache:
+```js
+module.exports = function (grunt) {
+  // Project configuration.
+  grunt.initConfig({
+    options: {
+      wrapper: 'define(["can", "can/view/stache"], function(can) { {{{content}}} });'
+    },
+    cancompile: {
+      dist: {
+        src: ['**/*.stache', '!node_modules/**/*.stache'],
         dest: 'production/views.production.js',
       }
     }


### PR DESCRIPTION
1) I’ve added an skip -files of all mustache-files in node_modules dir.

2) I’ve added an skip-files of all stache files in node_modules

3) added define([“can”, … because if can/view/stache was the only
require and it would overwrite the can variable in function(can) { ...
