### PR TITLE
Make task pipeable, allow optional dependencies in '.task' helper

### DIFF
--- a/gulp.js
+++ b/gulp.js
@@ -1,7 +1,75 @@
 'use strict';
 
 var compile = require('./lib/index.js');
-var glob = require('glob');
+var path = require('path');
+var through = require("through2");
+
+
+function runCompile(file, options) {
+  var templatePaths = [],
+    latestFile;
+
+  options = options || {};
+  
+  function bufferStream (file, enc, cb) {
+    // ignore empty files
+    if (file.isNull()) {
+      cb();
+      return;
+    }
+
+    // can't do streams yet
+    if (file.isStream()) {
+      this.emit('error', new PluginError('can-compile',  'Streaming not supported'));
+      cb();
+      return;
+    }
+
+    // set latest file if not already set,
+    // or if the current file was modified more recently.
+    if (!latestFile || file.stat && file.stat.mtime > latestFile.stat.mtime) {
+      latestFile = file;
+    }
+
+    templatePaths.push(file.path);
+    cb();
+  }
+
+  function endStream(cb) {
+    var self = this;
+
+    // no files passed in, no file goes out
+    if (!latestFile || !templatePaths.length) {
+      cb();
+      return;
+    }
+
+    compile(templatePaths, options, function (err, result) {
+      if (err) return cb(err);
+
+      var joinedFile;
+
+      // if file opt was a file path
+      // clone everything from the latest file
+      if (typeof file === 'string') {
+        joinedFile = latestFile.clone({ contents: false });
+        joinedFile.path = path.join(latestFile.base, file);
+      } else {
+        joinedFile = new File(file);
+      }
+
+      joinedFile.contents = new Buffer(result);
+
+      self.push(joinedFile);
+
+      cb();
+    });
+  }
+
+  return through.obj(bufferStream, endStream);
+}
+
+module.exports = runCompile;
 
 /**
  * Create a new gulp task to compile CanJS templates.
@@ -9,19 +77,16 @@ var glob = require('glob');
  * @param  {object} options  same as for can-compile's options.
  * @param  {gulp} pass in your gulp instance, so it registers the task correctly.
  */
-exports.task = function(taskName, options, gulp){
+module.exports.task = function(taskName, options, gulp, deps){
+  var destName = path.basename(options.out, '.js') + '.js';
+  var destPath = path.dirname(options.out);
 
-  gulp.task(taskName, function() {
+  deps = deps || [];
 
-    // Glob needs a string, but compiler needs an array.
-    options.glob = options.src.join();
-
-    glob(options.glob, function (er, files) {
-      compile(files, options, function(error, output, outfile) {
-        console.log('Finished compiling', outfile);
-      });
-    });
-
+  gulp.task(taskName, deps, function() {
+    return gulp.src( options.src )
+      .pipe( runCompile(destName, options) )
+      .pipe( gulp.dest(destPath) );
   });
 };
 
@@ -32,7 +97,7 @@ exports.task = function(taskName, options, gulp){
  * @param  {object} options  same as for can-compile's options.
  * @param  {gulp} pass in your gulp instance, so it registers the task correctly.
  */
-exports.watch = function(taskName, options, gulp){
+module.exports.watch = function(taskName, options, gulp){
   gulp.task(taskName + '-watch', function() {
     // Rerun the task when a file changes
     gulp.watch(options.src, [taskName]);

--- a/gulp.js
+++ b/gulp.js
@@ -15,18 +15,9 @@ function runCompile(file, options) {
   }
 
   var templatePaths = [],
-      fileName,
       latestFile;
 
   options = options || {};
-
-  if (typeof file === 'string') {
-    fileName = file;
-  } else if (typeof file.path === 'string') {
-    fileName = path.basename(file.path);
-  } else {
-    throw new PluginError('can-compile', 'Missing path in file options for can-compile');
-  }
   
   function bufferStream (file, enc, cb) {
     // ignore empty files

--- a/package.json
+++ b/package.json
@@ -36,12 +36,13 @@
     "grunt-simple-mocha": "~0.4.0"
   },
   "dependencies": {
-    "commander": "1.1.1",
     "async": "0.1.22",
-    "jsdom": "^3.0.0",
-    "handlebars": "~1.0.12",
+    "commander": "1.1.1",
     "glob": "~3.2.8",
-    "semver" : "~4.3.1"
+    "handlebars": "~1.0.12",
+    "jsdom": "^3.0.0",
+    "semver": "~4.3.1",
+    "through2": "^2.0.0"
   },
   "peerDependencies": {
     "grunt": "~0.4.0"

--- a/package.json
+++ b/package.json
@@ -33,12 +33,15 @@
     "grunt-cli": "~0.1.9",
     "grunt-contrib-jshint": ">= 0.1.1",
     "grunt-release": "~0.5.1",
-    "grunt-simple-mocha": "~0.4.0"
+    "grunt-simple-mocha": "~0.4.0",
+    "gulp": "^3.9.0",
+    "stream-assert": "^2.0.3"
   },
   "dependencies": {
     "async": "0.1.22",
     "commander": "1.1.1",
     "glob": "~3.2.8",
+    "gulp-util": "^3.0.6",
     "handlebars": "~1.0.12",
     "jsdom": "^3.0.0",
     "semver": "~4.3.1",

--- a/readme.md
+++ b/readme.md
@@ -9,27 +9,6 @@ With NodeJS installed, just run NPM:
 
 > npm install can-compile -g
 
-## Command line
-
-The `can-compile` command line tool takes a list of files (by default all `*.ejs` and `*.mustache` files in the current folder)
-or a list of [filename patterns](https://github.com/isaacs/minimatch) and writes the compiled views into an `out` file
-(default: `views.production.js`).
-
-__Examples:__
-
-Compile all EJS and Mustache files in the current folder and write them to `views.combined.js` using version 2.1.0:
-
-> can-compile --out views.combined.js --can 2.1.0
-
-Compile `todo.ejs` using CanJS version 1.1.2, write it to `views.production.js`:
-
-> can-compile todo.ejs --can 1.1.2
-
-Compile all EJS files in the current directory and all subdirectories and `mustache/test.mustache`.
-Write the result to `views.combined.js`:
-
-> can-compile **/*.ejs mustache/test.mustache --out views.combined.js --can 2.0.0
-
 ## Grunt task
 
 can-compile also comes with a [Grunt](http://gruntjs.com) task so you can easily make it part of your production build.
@@ -93,22 +72,40 @@ module.exports = function (grunt) {
 
 ## Gulp task
 
-It is also quite easy to get this up and running with your production build using Gulp.  By placing the following example in your gulpfile.js, all mustache templates in the client/app directory will be compiled into a file at public/assets/views.production.js.
+It is also quite easy to get this up and running with your production build using Gulp.  By placing the following example in your gulpfile.js, all mustache templates in the client/app directory will be compiled into a file at `public/assets/views.production.js`.
 
 ```javascript
-
-var gulp = require('gulp'),
-    compilerGulp = require('can-compile/gulp.js');
+var gulp = require('gulp');
+var compilerGulp = require('can-compile/gulp.js');
 
 var options = {
-  version: '2.0.0',
+	version: '2.2.7'
+};
+    
+gulp.task("app-views", function () {
+	return gulp.src('client/app/**/*.mustache')
+		.pipe( compilerGulp('views.production.js', options) )
+		.pipe( gulp.dest('public/assets') );
+});
+```
+**Or you can use available helpers to create your task and watch your files:**
+
+```javascript
+var gulp = require('gulp');
+var compilerGulp = require('can-compile/gulp.js');
+    
+var options = {
+  version: '2.2.7',
   src: ['client/app/**/*.mustache'],
   out: 'public/assets/views.production.js',
   tags: ['editor', 'my-component']
 };
 
-// Creates a task called 'app-views'.  Must pass in same gulp instance.
-compilerGulp.task('app-views', options, gulp);
+// Creates a task called 'app-views'.
+// You must pass in the same gulp instance.
+// You may also pass optional task dependencies (ex. 'clean')
+compilerGulp.task('app-views', options, gulp, ['clean']);
+
 // Creates a task called 'app-views-watch'. Optional, but convenient.
 compilerGulp.watch('app-views', options, gulp);
 
@@ -170,6 +167,27 @@ compiler.compile({
 });
 ```
 
+## Command line
+
+The `can-compile` command line tool takes a list of files (by default all `*.ejs` and `*.mustache` files in the current folder)
+or a list of [filename patterns](https://github.com/isaacs/minimatch) and writes the compiled views into an `out` file
+(default: `views.production.js`).
+
+__Examples:__
+
+Compile all EJS and Mustache files in the current folder and write them to `views.combined.js` using version 2.1.0:
+
+> can-compile --out views.combined.js --can 2.1.0
+
+Compile `todo.ejs` using CanJS version 1.1.2, write it to `views.production.js`:
+
+> can-compile todo.ejs --can 1.1.2
+
+Compile all EJS files in the current directory and all subdirectories and `mustache/test.mustache`.
+Write the result to `views.combined.js`:
+
+> can-compile **/*.ejs mustache/test.mustache --out views.combined.js --can 2.0.0
+
 ## Loading with RequireJS
 
 To use your pre-compile views with [RequireJS](http://requirejs.org/) just add a custom `wrapper` in the options
@@ -177,7 +195,8 @@ that uses the AMD definition to load `can/view/mustache` and/or `can/view/ejs` (
 In a Grunt task:
 
 Mustache:
-```js
+
+```javascript
 module.exports = function (grunt) {
   // Project configuration.
   grunt.initConfig({
@@ -195,7 +214,8 @@ module.exports = function (grunt) {
 ```
 
 Stache:
-```js
+
+```javascript
 module.exports = function (grunt) {
   // Project configuration.
   grunt.initConfig({


### PR DESCRIPTION
Fixes issues described in #41 - for the most part just implemented `gulp-concat` with can-compile injected at the end.