### PR TITLE
Add proxy support for canjs files download.

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -37,7 +37,7 @@ module.exports = function(options, callback) {
     return callback(new Error('A specific CanJS version number must be passed to compile views.'));
   }
 
-  visit(options.version, resolveScripts(options.version, options.paths), function(error, win) {
+  visit(options.version, resolveScripts(options.version, options.paths, options.proxy), function(error, win) {
     if (typeof options.log === 'function') {
       options.log('Compiling ' + filename);
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,7 +23,8 @@ module.exports = function(files, configuration, callback, log) {
         extensions: configuration.extensions,
         viewAttributes: configuration.viewAttributes,
         version: configuration.version,
-        paths: configuration.paths
+        paths: configuration.paths,
+        proxy: configuration.proxy
       }, function(error, compiled, id) {
         if (error) {
           return callback(error);

--- a/lib/resolveScripts.js
+++ b/lib/resolveScripts.js
@@ -39,20 +39,41 @@ var getScript = function(canVersion, script, paths) {
   }
 };
 
-var getPlugins = function(canVersion, paths) {
+var getPlugins = function(canVersion, paths, proxy) {
   var plugins = [];
   for(var plugin in versionMap.plugins) {
     if(semver.satisfies(canVersion, versionMap.plugins[plugin])){
-      plugins.push(getScript(canVersion, plugin, paths));
+      plugins.push(proxyUrl(getScript(canVersion, plugin, paths), proxy));
     }
   }
   return plugins;
 };
 
-module.exports = function(version, paths) {
+var proxyUrl = function(url, proxy){
+  if (!proxy) {
+    return url;
+  }
+  return {
+    host: proxy.host,
+    port: proxy.port,
+    path: url,
+    headers: {
+      Host: url
+    },
+
+    // fake function for doc-helpers
+    match : function(){
+      return true;
+    }
+  };
+}
+
+module.exports = function(version, paths, proxy) {
   var scripts = [];
-  scripts.push(getjQuery(version, paths));
-  scripts.push(getScript(version, 'can', paths));
-  scripts = scripts.concat(getPlugins(version, paths));
+
+  scripts.push(proxyUrl(getjQuery(version, paths),proxy));
+  scripts.push(proxyUrl(getScript(version, 'can', paths),proxy));
+  scripts = scripts.concat(getPlugins(version, paths, proxy));
+
   return scripts;
 };

--- a/readme.md
+++ b/readme.md
@@ -175,6 +175,7 @@ The options object allows the following configuration options:
 - `extensions` {Object}: An object to map custom file extensions to the standard extension (e.g. `{ 'mst' : 'mustache' }`)
 - `viewAttributes` {Array}: A list of attribute names (RegExp or String), used for additional behavior for an attribute in a view (can.view.attr)
 - `paths` an object with `ejs`, `mustache` or `stache` and a `jquery` property pointing to files of existing versions or CanJS and jQuery instead of the CDN links.
+- `proxy` an object with `host` {String} and `port` {Number} properties
 
 ```javascript
 compiler.compile({


### PR DESCRIPTION
I propose this request to add the capability to execute can-compile with a proxy. I tried "globalTunnel" without success. So I implement this new option "proxy" 