### PR TITLE
Use v2.canjs.com for the release scripts

### DIFF
--- a/lib/resolveScripts.js
+++ b/lib/resolveScripts.js
@@ -5,10 +5,10 @@ var versionMap = require('./version-map.json');
 
 var defaultPaths = {
   'jquery': Handlebars.compile('http://ajax.googleapis.com/ajax/libs/jquery/{{version}}/jquery.min.js'),
-  'can': Handlebars.compile('http://canjs.com/release/{{version}}/can.jquery.js'),
-  'ejs': Handlebars.compile('http://canjs.com/release/{{version}}/can.ejs.js'),
-  'mustache': Handlebars.compile('http://canjs.com/release/{{version}}/can.view.mustache.js'),
-  'stache': Handlebars.compile('http://canjs.com/release/{{version}}/can.stache.js')
+  'can': Handlebars.compile('http://v2.canjs.com/release/{{version}}/can.jquery.js'),
+  'ejs': Handlebars.compile('http://v2.canjs.com/release/{{version}}/can.ejs.js'),
+  'mustache': Handlebars.compile('http://v2.canjs.com/release/{{version}}/can.view.mustache.js'),
+  'stache': Handlebars.compile('http://v2.canjs.com/release/{{version}}/can.stache.js')
 };
 
 var getScriptFromPath = function(scriptPath) {

--- a/test/test.js
+++ b/test/test.js
@@ -151,9 +151,9 @@ describe('resolving scripts', function(){
       expect(resolveScripts('2.1.3')).to.contain('http://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js', '2.1.3 includes jQuery 2.1.3');
     });
     it('includes the right plugins', function(){
-      expect(resolveScripts('1.1.5')).to.contain('http://canjs.com/release/1.1.5/can.view.mustache.js', '1.1.5 includes mustache');
-      expect(resolveScripts('2.1.3')).to.contain('http://canjs.com/release/2.1.3/can.ejs.js', '2.1.3 includes ejs');
-      expect(resolveScripts('2.1.3')).to.contain('http://canjs.com/release/2.1.3/can.stache.js', '2.1.3 includes stache');
+      expect(resolveScripts('1.1.5')).to.contain('http://v2.canjs.com/release/1.1.5/can.view.mustache.js', '1.1.5 includes mustache');
+      expect(resolveScripts('2.1.3')).to.contain('http://v2.canjs.com/release/2.1.3/can.ejs.js', '2.1.3 includes ejs');
+      expect(resolveScripts('2.1.3')).to.contain('http://v2.canjs.com/release/2.1.3/can.stache.js', '2.1.3 includes stache');
     });
   });
 
@@ -254,7 +254,7 @@ describe('gulp task', function () {
     });
 
     it('should extract the file path/name from the "out" option', function (done) {
-      gulpCompile.task('cancompile', { 
+      gulpCompile.task('cancompile', {
         src: __dirname + '/fixtures/*',
         out: __dirname + '/views.production.js',
         version: '2.2.7'
@@ -270,4 +270,3 @@ describe('gulp task', function () {
     });
   });
 });
-


### PR DESCRIPTION
This assumes that `can-compile` is only used with CanJS 1 or 2, because the CanJS 3 scripts aren’t hosted on `v2.canjs.com`. I think this is an okay assumption for now because `can-compile` isn’t listed on the new site.

Fixes #52