### PR TITLE
Use canjs.com instead of v2.canjs.com

### DIFF
--- a/lib/resolveScripts.js
+++ b/lib/resolveScripts.js
@@ -14,10 +14,10 @@ Handlebars.registerHelper("systemifv2", function(version) {
 
 var defaultPaths = {
   'jquery': Handlebars.compile('http://ajax.googleapis.com/ajax/libs/jquery/{{version}}/jquery.min.js'),
-  'can': Handlebars.compile('http://v2.canjs.com/release/{{version}}/can.jquery.js'),
-  'ejs': Handlebars.compile('http://v2.canjs.com/release/{{version}}/can.ejs.js'),
-  'mustache': Handlebars.compile('http://v2.canjs.com/release/{{version}}/can.view.mustache{{systemifv2 version}}.js'),
-  'stache': Handlebars.compile('http://v2.canjs.com/release/{{version}}/can.stache.js')
+  'can': Handlebars.compile('http://canjs.com/release/{{version}}/can.jquery.js'),
+  'ejs': Handlebars.compile('http://canjs.com/release/{{version}}/can.ejs.js'),
+  'mustache': Handlebars.compile('http://canjs.com/release/{{version}}/can.view.mustache{{systemifv2 version}}.js'),
+  'stache': Handlebars.compile('http://canjs.com/release/{{version}}/can.stache.js')
 };
 
 var getScriptFromPath = function(scriptPath) {


### PR DESCRIPTION
The v2.canjs.com domain shouldn’t have been used. canjs.com/release/ will get updated when new versions of CanJS 2.3 are released, and it’s currently up to date.

Fixes https://github.com/canjs/canjs/issues/3209